### PR TITLE
Update node engine to 6.11.x

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -25,7 +25,7 @@
         "jest": "20.0.4"
     },
     "engines": {
-        "node": "6.9.x"
+        "node": "6.11.x"
     },
     "scripts": {
         "flow-typed": "flow-typed install",

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,5 +1,5 @@
 
-box: node:6.9
+box: node:6.11
 
 build:
 


### PR DESCRIPTION
node 6.9.x has vulnerabilities, plus this restriction prevents Renovate from generating the `yarn.lock` with 6.11.x